### PR TITLE
Can now add attachments to the email

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -378,6 +378,16 @@ Sets the subaccount field of the message
 message.subaccount('MyMandrillSubaccount');
 ```
 
+### message.attach(mime_type, file_name, base64_encoded_file_body)
+
+Adds an attachment to include in the email. The body should be a base64 encoded string.
+
+```js
+var fs = require('fs');
+var file = fs.readFileSync('test.pdf');
+message.attach('application/pdf', 'test.pdf', file.toString('base64'));
+```
+
 ## Planned features
 
 These are some ideas that I have to extend the library. Please open issues to

--- a/lib/message.js
+++ b/lib/message.js
@@ -21,9 +21,19 @@ function Powerdrill(apiKey, template) {
   this._template = template;
   this._templateContent = [];
   this._subaccount = null;
+  this._attachments = [];
 }
 
 module.exports = Powerdrill;
+
+
+Powerdrill.prototype.attach = function(type, name, content) {
+  this._attachments.push({
+    type: type,
+    name: name,
+    content: content
+  });
+};
 
 Powerdrill.prototype.subaccount = function(subaccount) {
   this._subaccount = subaccount;
@@ -156,6 +166,7 @@ Powerdrill.prototype.requestData = function() {
       merge_vars: this._mergeVars,
       tags: this._tags,
       metadata: this._metadata,
+      attachments: this._attachments,
       recipient_metadata: this._userMetadata
     }
   };

--- a/test/powerdrill.js
+++ b/test/powerdrill.js
@@ -101,6 +101,10 @@ describe('Message', function() {
     it("sets the template name", function() {
       expect(message._template).to.be('template');
     });
+
+    it("sets the attachments to empty array", function() {
+      expect(message._attachments).to.be.an.array;
+    });
   });
 
   describe("#apiKey", function() {
@@ -127,6 +131,18 @@ describe('Message', function() {
 
     it("returns the message", function() {
       expect(message.template('123')).to.be(message);
+    });
+  });
+
+  describe("#attach", function() {
+    it("builds the attachments array", function () {
+      message.attach("application/pdf", "test.pdf", "SOMEBASE64STRING");
+      expect(message._attachments).to.be.an.array;
+      expect(message._attachments.length).to.be(1);
+      expect(message._attachments[0]).to.be.an.object;
+      expect(message._attachments[0].type).to.be('application/pdf');
+      expect(message._attachments[0].name).to.be('test.pdf');
+      expect(message._attachments[0].content).to.be('SOMEBASE64STRING');
     });
   });
 
@@ -636,6 +652,19 @@ describe('Message', function() {
         message.send(done);
     });
   });
+    describe("with attachment", function () {
+      it("attachment is part of the message to Mandrill", function () {
+        message = new Message('123');
+        message.attach('application/pdf', 'file.pdf', 'SOMEBASE64STRING');
+        var request = message.requestData();
+        expect(request.message.attachments).to.be.an.array;
+        expect(request.message.attachments.length).to.be(1);
+        expect(request.message.attachments[0]).to.be.an.object;
+        expect(request.message.attachments[0].name).to.be('file.pdf');
+        expect(request.message.attachments[0].type).to.be('application/pdf');
+        expect(request.message.attachments[0].content).to.be('SOMEBASE64STRING');
+      });
+    });
 
     describe('with skip', function() {
       it("doesn't call the api", function(done) {


### PR DESCRIPTION
Hi Ryan,

Me again. This time I needed to be able to add attachments to the emails we are sending. Attached is a pull request that adds the support.

Thanks again,

Lucas.
