### PR TITLE
Fix chaining with duplicate emails

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -163,12 +163,12 @@ Powerdrill.prototype.metadata = function(key, value) {
 Powerdrill.prototype.to = function(address, mergeVars, metaData) {
   var email = parseEmail(address);
   email.type = 'to';
+  this._to.push(email);
   if (this._presentEmails.indexOf(email.email) != -1) {
     console.warn("Powerdrill: Attempting to add the same email twice. Using data from first instance");
-    return;
+    return this;
   }
   this._presentEmails.push(email.email);
-  this._to.push(email);
   if(mergeVars) this.mergeVar(email.email, mergeVars);
   if(metaData) this.userMetadata(email.email, metaData);
   return this;

--- a/test/powerdrill.js
+++ b/test/powerdrill.js
@@ -479,6 +479,7 @@ describe('Message', function() {
         console.warn = function() { called = true; console.warn = warn; };
         message.to('John Doe <john@gmail.com');
         message.to('John Doe <john@gmail.com');
+        expect(message._to.length).to.be(2);
         expect(called).to.be.ok();
       });
 


### PR DESCRIPTION
Hey Ryan,

I came across a problem where my code failed when duplicate recipients were added to the message. Specifically the method chaining broke because .to() returned nothing, but normally returns the message.

I also noticed that the duplicated address wasn't added, despite the warning that it would be, but would have the first attempt's merge variables. 

I've rearranged those few lines to fix them both and modified the unit test to ensure that the address got added again.

Let me know if this is acceptable and if so, when you add it to NPM so I can kick off a new deployment of my app.

Thanks,

Lucas.