### PR TITLE
Add ability to mark recipient as cc or bcc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Powerdrill
-[![Build Status](https://api.travis-ci.org/rschmukler/powerdrill.png)](http://travis-ci.org/rschmukler/powerdrill) 
+[![Build Status](https://api.travis-ci.org/rschmukler/powerdrill.png)](http://travis-ci.org/rschmukler/powerdrill)
 [![Coverage Status](https://coveralls.io/repos/rschmukler/powerdrill/badge.png)](https://coveralls.io/r/rschmukler/powerdrill)
 
 Mandrill with power!
@@ -43,7 +43,7 @@ Or with pure html:
 ```js
 var email = require('powerdrill')('myApiKey');
 
-var message = email(); 
+var message = email();
 
 message
 .subject('Thanks for registering')
@@ -216,7 +216,7 @@ message.text('Hello World');
 Additionally, for a multipart message with HTML and plain text, you can add both parts manually.
 
 ```js
-message.html('<h1>Hello world</h1>'); 
+message.html('<h1>Hello world</h1>');
 message.text('Hello world');
 ```
 
@@ -239,11 +239,18 @@ message.from('ryan@slingingcode.com');
 message.from('Ryan Schmukler <ryan@slingingcode.com>');
 ```
 
-#### message.to(address, recipientVariables, recipientMetadata)
+#### message.to(address, recipientVariables, recipientMetadata, type)
 
 Adds a recipient. Call multiple times to add multiple recipients.
-`recipientVariables` and `recipientMetadata` are both optional. See below for
-other ways to add.
+`recipientVariables`, `recipientMetadata` and `type` are all optional. See below
+for other ways to add.
+
+Valid types are:
+* to (default)
+* cc
+* bcc
+
+Invalid types fall back to "to".
 
 simple:
 ```js
@@ -252,7 +259,7 @@ message.to('ryan@slingingcode.com');
 
 complex:
 ```js
-message.to('Ryan Schmukler <ryan@slingingcode.com>', {name: 'Ryan'}, {uid: 123})
+message.to('Ryan Schmukler <ryan@slingingcode.com>', {name: 'Ryan'}, {uid: 123}, 'cc')
 ```
 
 ### message.trackClicks(val)
@@ -315,7 +322,7 @@ message.tag('easy');
 
 ### message.important(val)
 
-Sets the message as important, prioritizing it in mandrill's queue. 
+Sets the message as important, prioritizing it in mandrill's queue.
 
 `val` is optional, but setting it to false will mark it back to not important (default).
 
@@ -393,7 +400,7 @@ message.metadata({someVar: someValue});
 
 Aliased to `message.recipientMetadata`.
 
-Adds a variable for a specific recipient for use in mandrill's recipient metadata. 
+Adds a variable for a specific recipient for use in mandrill's recipient metadata.
 See `message#to` for a shortcut.
 
 Takes an object of variables.

--- a/lib/message.js
+++ b/lib/message.js
@@ -160,9 +160,12 @@ Powerdrill.prototype.metadata = function(key, value) {
   return this;
 };
 
-Powerdrill.prototype.to = function(address, mergeVars, metaData) {
+Powerdrill.prototype.to = function(address, mergeVars, metaData, type) {
   var email = parseEmail(address);
-  email.type = 'to';
+  email.type = type || 'to';
+  if (['to', 'cc', 'bcc'].indexOf(email.type) < 0) {
+      email.type = 'to';
+  }
   this._to.push(email);
   if (this._presentEmails.indexOf(email.email) != -1) {
     console.warn("Powerdrill: Attempting to add the same email twice. Using data from first instance");

--- a/test/powerdrill.js
+++ b/test/powerdrill.js
@@ -453,6 +453,24 @@ describe('Message', function() {
   });
 
   describe('#to', function() {
+    it('defaults to "to" type', function() {
+        message.to('John Doe <john@gmail.com>');
+        expect(message._to[0]).to.have.property('type', 'to');
+    });
+    it('can be set to "cc"', function() {
+        message.to('Jane Doe <john@gmail.com>', {}, {}, "cc");
+        expect(message._to[0]).to.have.property('type', 'cc');
+    });
+    it('can be set to "bcc"', function() {
+        message.to('Jane Doe <john@gmail.com>', {}, {}, "bcc");
+        expect(message._to[0]).to.have.property('type', 'bcc');
+    });
+    it('fall back to "to" if invalid type given', function() {
+        message.to('Jane Doe <john@gmail.com>', {}, {}, "garbage");
+        expect(message._to[0]).to.have.property('type', 'to');
+    });
+
+
     it('adds the recipient', function() {
       message.to('John Doe <john@gmail.com>');
       expect(message._to[0]).to.have.property('name', 'John Doe');


### PR DESCRIPTION
Hey Ryan,

I've created this PR to add the ability to set recipients as CC or BCC as is needed by my project. It looks like you'd started here by explicitly marking them "to", I've just added an optional parameter and updated the docs and unit tests to cover it.

Thanks,

Lucas.