### PR TITLE
Add ability to attach images for use in-line

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -242,7 +242,7 @@ message.from('Ryan Schmukler <ryan@slingingcode.com>');
 #### message.to(address, recipientVariables, recipientMetadata)
 
 Adds a recipient. Call multiple times to add multiple recipients.
-`recipientVariables` and `recipientMetadata` are optional. 
+`recipientVariables` and `recipientMetadata` are optional.
 See below for other ways to add.
 
 simple:
@@ -257,7 +257,7 @@ message.to('Ryan Schmukler <ryan@slingingcode.com>', {name: 'Ryan'}, {uid: 123})
 
 #### message.bcc(address, recipientVariables, recipientMetadata)
 
-Adds a recipient that will be BCC'd. `recipientVariables` and `recipientMetadata` 
+Adds a recipient that will be BCC'd. `recipientVariables` and `recipientMetadata`
 are optional. See below for other ways to add.
 
 ```js
@@ -266,7 +266,7 @@ message.bcc('ryan@slingingcode.com');
 
 #### message.cc(address, recipientVariables, recipientMetadata)
 
-Adds a recipient that will be CC'd. `recipientVariables` and `recipientMetadata` 
+Adds a recipient that will be CC'd. `recipientVariables` and `recipientMetadata`
 are optional. See below for other ways to add.
 
 ```js
@@ -455,6 +455,16 @@ Adds an attachment to include in the email. The body should be a base64 encoded 
 var fs = require('fs');
 var file = fs.readFileSync('test.pdf');
 message.attach('application/pdf', 'test.pdf', file.toString('base64'));
+```
+
+### message.image(mime_type, image_name, base64_encoded_image_body)
+
+Adds an image to include in-line in the email. The body should be a base64 encoded string.
+
+```js
+var fs = require('fs');
+var image = fs.readFileSync('test.png');
+message.image('image/png', 'test.png', image.toString('base64'));
 ```
 
 ## Planned features

--- a/lib/message.js
+++ b/lib/message.js
@@ -24,11 +24,19 @@ function Powerdrill(apiKey, template) {
   this._templateContent = [];
   this._subaccount = null;
   this._attachments = [];
+  this._images = [];
   this._presentEmails = [];
 }
 
 module.exports = Powerdrill;
 
+Powerdrill.prototype.image = function(type, name, content){
+  this._images.images.push({
+    type: type,
+    name: name,
+    content: content
+  });
+};
 
 Powerdrill.prototype.attach = function(type, name, content) {
   this._attachments.push({
@@ -223,6 +231,7 @@ Powerdrill.prototype.requestData = function() {
       tags: this._tags,
       metadata: this._metadata,
       attachments: this._attachments,
+      images: this._images,
       recipient_metadata: this._userMetadata,
       track_clicks: this._trackClicks,
       track_opens: this._trackOpens

--- a/lib/message.js
+++ b/lib/message.js
@@ -36,6 +36,7 @@ Powerdrill.prototype.image = function(type, name, content){
     name: name,
     content: content
   });
+  return this;
 };
 
 Powerdrill.prototype.attach = function(type, name, content) {
@@ -44,6 +45,7 @@ Powerdrill.prototype.attach = function(type, name, content) {
     name: name,
     content: content
   });
+  return this;
 };
 
 Powerdrill.prototype.globalBcc = function(email) {

--- a/lib/message.js
+++ b/lib/message.js
@@ -31,7 +31,7 @@ function Powerdrill(apiKey, template) {
 module.exports = Powerdrill;
 
 Powerdrill.prototype.image = function(type, name, content){
-  this._images.images.push({
+  this._images.push({
     type: type,
     name: name,
     content: content

--- a/test/powerdrill.js
+++ b/test/powerdrill.js
@@ -547,6 +547,10 @@ describe('Message', function() {
       expect(message._images[0].type).to.be.a('string');
       expect(message._images[0].content).to.be.a('string');
     });
+
+    it('returns the message', function() {
+      expect(message.image('image/png', 'testImage', 'SOMEBASE64')).to.be(message);
+    });
   });
 
   describe('#attach', function() {
@@ -557,6 +561,10 @@ describe('Message', function() {
       expect(message._attachments[0].name).to.be.a('string');
       expect(message._attachments[0].type).to.be.a('string');
       expect(message._attachments[0].content).to.be.a('string');
+    });
+
+    it('returns the message', function() {
+      expect(message.attach('application/pdf', 'document.pdf', 'SOMEBASE64')).to.be(message);
     });
   });
 

--- a/test/powerdrill.js
+++ b/test/powerdrill.js
@@ -538,6 +538,28 @@ describe('Message', function() {
     });
   });
 
+  describe('#image', function() {
+    it("adds the image to the array", function() {
+      message.image('image/png', 'testImage', 'SOMEBASE64');
+      expect(message._images.length).to.be.above(0);
+      expect(message._images[0]).to.be.a('object');
+      expect(message._images[0].name).to.be.a('string');
+      expect(message._images[0].type).to.be.a('string');
+      expect(message._images[0].content).to.be.a('string');
+    });
+  });
+
+  describe('#attach', function() {
+    it("adds the attachment to the array", function() {
+      message.attach('application/pdf', 'document.pdf', 'SOMEBASE64');
+      expect(message._attachments.length).to.be.above(0);
+      expect(message._attachments[0]).to.be.a('object');
+      expect(message._attachments[0].name).to.be.a('string');
+      expect(message._attachments[0].type).to.be.a('string');
+      expect(message._attachments[0].content).to.be.a('string');
+    });
+  });
+
   describe('#requestData', function() {
     var request, message;
     beforeEach(function() {
@@ -654,6 +676,16 @@ describe('Message', function() {
       expect(recipientMetadata[0]).to.have.property('rcpt', 'user@test.com');
       expect(recipientMetadata[0]).to.have.property('values');
       expect(recipientMetadata[0].values).to.have.property('uid', 123);
+    });
+
+    it('includes attachments', function() {
+      request = message.requestData();
+      expect(message._attachments).to.be.an(Array);
+    });
+
+    it('includes images', function() {
+      request = message.requestData();
+      expect(message._images).to.be.an(Array);
     });
   });
 


### PR DESCRIPTION
Added a method message.image() to allow you to embed base64 images.
For use inline with `<img src="cid:image_name">`