### PR TITLE
Added setAPI method for test purpose

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -269,6 +269,10 @@ Powerdrill.prototype.send = function(done) {
   return this;
 };
 
+Powerdrill.prototype.setAPI = function (API) {
+  API_ENDPOINT = API;
+};
+
 function parseEmail(email) {
   var address, name, match;
 


### PR DESCRIPTION
Hello

I don't want to send real emails from my test environment as well as bother mandrill service. Instead I would like to catch the library calls on my side for further processing and checks inside tests. As soon as API_ENDPOINT variable is private and sendTemplate/sendHtml methods are private too I didn't find better solution but adding a setter for API_ENDPOINT. It will be handy if you add this to your code.

Thanks,
Vasiliy